### PR TITLE
Formatting fixes only.

### DIFF
--- a/Exec/DevTests/Bomex/input_SAM
+++ b/Exec/DevTests/Bomex/input_SAM
@@ -54,24 +54,24 @@ erf.Cs              = 0.1
 erf.init_type = "input_sounding"
 erf.init_sounding_ideal = true
 
-# Higher values of perturbations lead to instability
-# Instability seems to be coming from BC
-prob.U_0_Pert_Mag = 0.01
-prob.V_0_Pert_Mag = 0.01 #
-prob.W_0_Pert_Mag = 0.0
-
-prob.pert_ref_height = 400.0
-prob.T_pert       = 0.1
-prob.qv_pert      = 0.025
-
 erf.add_custom_rhotheta_forcing = true
 erf.add_custom_moisture_forcing = true
 erf.custom_forcing_uses_primitive_vars = false
 
-erf.advection_heating_rate   = -2.3148E-5
-erf.source_cutoff            = 1500.0
-erf.source_cutoff_transition = 3000.0
+# Higher values of perturbations lead to instability
+# Instability seems to be coming from BC
+prob.U_0_Pert_Mag = 0.01
+prob.V_0_Pert_Mag = 0.01 
+prob.W_0_Pert_Mag = 0.0
 
-erf.advection_moisture_rate   		= -1.2E-8
-erf.moisture_source_cutoff            	= 300.0
-erf.moisture_source_cutoff_transition 	= 500.0
+prob.pert_ref_height = 400.0
+prob.T_pert          = 0.1
+prob.qv_pert         = 0.025
+
+prob.advection_heating_rate   = -2.3148E-5
+prob.source_cutoff            = 1500.0
+prob.source_cutoff_transition = 3000.0
+
+prob.advection_moisture_rate   		    = -1.2E-8
+prob.moisture_source_cutoff            	= 300.0
+prob.moisture_source_cutoff_transition 	= 500.0

--- a/Exec/DevTests/Bomex/prob.H
+++ b/Exec/DevTests/Bomex/prob.H
@@ -37,12 +37,12 @@ struct ProbParm : ProbParmDefaults {
   //==============================================
   // USER-DEFINED INPUTS
   // source terms
-  amrex::Real advection_heating_rate;
+  amrex::Real advection_heating_rate = 0.0;
   amrex::Real restart_time = 9e9;
   amrex::Real cutoff = 500.0;
   amrex::Real cutoff_transition = 50.0;
 
-  amrex::Real advection_moisture_rate;
+  amrex::Real advection_moisture_rate = 0.0;
   amrex::Real moisture_cutoff = 500.0;
   amrex::Real moisture_cutoff_transition = 50.0;
   //==============================================
@@ -57,7 +57,7 @@ struct ProbParm : ProbParmDefaults {
 class Problem : public ProblemBase
 {
 public:
-    Problem(const amrex::Real* problo, const amrex::Real* probhi);
+    Problem (const amrex::Real* problo, const amrex::Real* probhi);
 
 #include "Prob/init_constant_density_hse.H"
 #include "Prob/init_rayleigh_damping.H"
@@ -82,21 +82,21 @@ public:
         const SolverChoice& sc) override;
 
     void update_rhotheta_sources (
-        const amrex::Real& time,
+        const amrex::Real& /*time*/,
         amrex::Vector<amrex::Real>& src,
         amrex::Gpu::DeviceVector<amrex::Real>& d_src,
         const amrex::Geometry& geom,
         std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
 
     void update_rhoqt_sources (
-        const amrex::Real& time,
+        const amrex::Real& /*time*/,
         amrex::Vector<amrex::Real>& qsrc,
         amrex::Gpu::DeviceVector<amrex::Real>& d_qsrc,
         const amrex::Geometry& geom,
         std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
 
 protected:
-    std::string name() override { return "ABL"; }
+    std::string name () override { return "BOMEX"; }
 
 private:
     ProbParm parms;

--- a/Exec/DevTests/Bomex/prob.cpp
+++ b/Exec/DevTests/Bomex/prob.cpp
@@ -5,12 +5,12 @@
 using namespace amrex;
 
 std::unique_ptr<ProblemBase>
-amrex_probinit(const amrex_real* problo, const amrex_real* probhi)
+amrex_probinit (const amrex_real* problo, const amrex_real* probhi)
 {
     return std::make_unique<Problem>(problo, probhi);
 }
 
-Problem::Problem(const amrex::Real* problo, const amrex::Real* probhi)
+Problem::Problem (const amrex::Real* problo, const amrex::Real* probhi)
 {
   // Parse params
   ParmParse pp("prob");
@@ -42,11 +42,11 @@ Problem::Problem(const amrex::Real* problo, const amrex::Real* probhi)
 
   //===========================================================================
   // READ USER-DEFINED INPUTS
-  pp.get("advection_heating_rate", parms.advection_heating_rate);
+  pp.query("advection_heating_rate", parms.advection_heating_rate);
   pp.query("restart_time",parms.restart_time);
   pp.query("source_cutoff", parms.cutoff);
   pp.query("source_cutoff_transition", parms.cutoff_transition);
-  pp.get("advection_moisture_rate", parms.advection_moisture_rate);
+  pp.query("advection_moisture_rate", parms.advection_moisture_rate);
   pp.query("moisture_source_cutoff", parms.moisture_cutoff);
   pp.query("moisture_source_cutoff_transition", parms.moisture_cutoff_transition);
   //===========================================================================
@@ -55,7 +55,7 @@ Problem::Problem(const amrex::Real* problo, const amrex::Real* probhi)
 }
 
 void
-Problem::init_custom_pert(
+Problem::init_custom_pert (
     const amrex::Box&  bx,
     const amrex::Box& xbx,
     const amrex::Box& ybx,
@@ -181,7 +181,7 @@ Problem::init_custom_pert(
 // USER-DEFINED FUNCTION
 //=============================================================================
 void
-Problem::update_rhotheta_sources (const amrex::Real& time,
+Problem::update_rhotheta_sources (const amrex::Real& /*time*/,
                                   amrex::Vector<amrex::Real>& src,
                                   amrex::Gpu::DeviceVector<amrex::Real>& d_src,
                                   const amrex::Geometry& geom,
@@ -223,7 +223,7 @@ Problem::update_rhotheta_sources (const amrex::Real& time,
 // USER-DEFINED FUNCTION
 //=============================================================================
 void
-Problem::update_rhoqt_sources (const amrex::Real& time,
+Problem::update_rhoqt_sources (const amrex::Real& /*time*/,
                                amrex::Vector<amrex::Real>& qsrc,
                                amrex::Gpu::DeviceVector<amrex::Real>& d_qsrc,
                                const amrex::Geometry& geom,

--- a/Exec/DevTests/Bomex/prob.cpp
+++ b/Exec/DevTests/Bomex/prob.cpp
@@ -181,12 +181,11 @@ Problem::init_custom_pert(
 // USER-DEFINED FUNCTION
 //=============================================================================
 void
-Problem::update_rhotheta_sources (
-    const amrex::Real& time,
-    amrex::Vector<amrex::Real>& src,
-    amrex::Gpu::DeviceVector<amrex::Real>& d_src,
-    const amrex::Geometry& geom,
-    std::unique_ptr<amrex::MultiFab>& z_phys_cc)
+Problem::update_rhotheta_sources (const amrex::Real& time,
+                                  amrex::Vector<amrex::Real>& src,
+                                  amrex::Gpu::DeviceVector<amrex::Real>& d_src,
+                                  const amrex::Geometry& geom,
+                                  std::unique_ptr<amrex::MultiFab>& z_phys_cc)
 {
     if (src.empty()) return;
 
@@ -203,20 +202,19 @@ Problem::update_rhotheta_sources (
         zlevels.resize(khi+1);
         reduce_to_max_per_level(zlevels, z_phys_cc);
     }
-    
+
     // Only apply temperature source below nominal inversion height
-    for (int k = 0; k <= khi; k++) 
-    {
-    	const Real z_cc = (z_phys_cc) ? zlevels[k] : prob_lo[2] + (k+0.5)* dx[2];
-	if (z_cc < parms.cutoff) {
-		src[k] = parms.advection_heating_rate;
-	} else if (z_cc < parms.cutoff+parms.cutoff_transition) {
-		src[k] = parms.advection_heating_rate * (z_cc-parms.cutoff)/parms.cutoff_transition;
+    for (int k = 0; k <= khi; k++) {
+        const Real z_cc = (z_phys_cc) ? zlevels[k] : prob_lo[2] + (k+0.5)* dx[2];
+        if (z_cc < parms.cutoff) {
+            src[k] = parms.advection_heating_rate;
+        } else if (z_cc < parms.cutoff+parms.cutoff_transition) {
+            src[k] = parms.advection_heating_rate * (z_cc-parms.cutoff)/parms.cutoff_transition;
         } else {
-        	src[k] = 0.0;
+            src[k] = 0.0;
         }
     }
-    
+
     // Copy from host version to device version
     amrex::Gpu::copy(amrex::Gpu::hostToDevice, src.begin(), src.end(), d_src.begin());
 }
@@ -225,12 +223,11 @@ Problem::update_rhotheta_sources (
 // USER-DEFINED FUNCTION
 //=============================================================================
 void
-Problem::update_rhoqt_sources (
-    const amrex::Real& time,
-    amrex::Vector<amrex::Real>& qsrc,
-    amrex::Gpu::DeviceVector<amrex::Real>& d_qsrc,
-    const amrex::Geometry& geom,
-    std::unique_ptr<amrex::MultiFab>& z_phys_cc)
+Problem::update_rhoqt_sources (const amrex::Real& time,
+                               amrex::Vector<amrex::Real>& qsrc,
+                               amrex::Gpu::DeviceVector<amrex::Real>& d_qsrc,
+                               const amrex::Geometry& geom,
+                               std::unique_ptr<amrex::MultiFab>& z_phys_cc)
 {
     if (qsrc.empty()) return;
 
@@ -249,16 +246,15 @@ Problem::update_rhoqt_sources (
     }
 
     // Only apply temperature source below nominal inversion height
-    for (int k = 0; k <= khi; k++) 
-    {
-	const Real z_cc = (z_phys_cc) ? zlevels[k] : prob_lo[2] + (k+0.5)* dx[2];
-	if (z_cc < parms.moisture_cutoff) {
-		qsrc[k] = parms.advection_moisture_rate;
-	} else if (z_cc < parms.moisture_cutoff+parms.moisture_cutoff_transition) {
-                qsrc[k] = parms.advection_moisture_rate * (z_cc-parms.moisture_cutoff)/parms.moisture_cutoff_transition;
-	} else {
-                qsrc[k] = 0.0;
-	}
+    for (int k = 0; k <= khi; k++) {
+        const Real z_cc = (z_phys_cc) ? zlevels[k] : prob_lo[2] + (k+0.5)* dx[2];
+        if (z_cc < parms.moisture_cutoff) {
+            qsrc[k] = parms.advection_moisture_rate;
+        } else if (z_cc < parms.moisture_cutoff+parms.moisture_cutoff_transition) {
+            qsrc[k] = parms.advection_moisture_rate * (z_cc-parms.moisture_cutoff)/parms.moisture_cutoff_transition;
+        } else {
+            qsrc[k] = 0.0;
+        }
     }
 
     // Copy from host version to device version

--- a/Source/DataStructs/DataStruct.H
+++ b/Source/DataStructs/DataStruct.H
@@ -211,9 +211,9 @@ struct SolverChoice {
 
         pp.query("add_custom_rhotheta_forcing", custom_rhotheta_forcing);
         pp.query("add_custom_moisture_forcing", custom_moisture_forcing);
-	pp.query("custom_forcing_uses_primitive_vars", custom_forcing_prim_vars);
+        pp.query("custom_forcing_uses_primitive_vars", custom_forcing_prim_vars);
 
-	pp.query("Ave_Plane", ave_plane);
+        pp.query("Ave_Plane", ave_plane);
 
         pp.query("mp_clouds", do_cloud);
         pp.query("mp_precip", do_precip);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -637,12 +637,11 @@ ERF::InitData ()
     {
         h_rhotheta_src.resize(max_level+1, amrex::Vector<Real>(0));
         d_rhotheta_src.resize(max_level+1, amrex::Gpu::DeviceVector<Real>(0));
-        for (int lev = 0; lev <= finest_level; lev++)
-        {
+        for (int lev = 0; lev <= finest_level; lev++) {
             const int domlen = geom[lev].Domain().length(2);
-	    h_rhotheta_src[lev].resize(domlen, 0.0_rt);
+            h_rhotheta_src[lev].resize(domlen, 0.0_rt);
             d_rhotheta_src[lev].resize(domlen, 0.0_rt);
-	    prob->update_rhotheta_sources(t_new[0],
+            prob->update_rhotheta_sources(t_new[0],
                                           h_rhotheta_src[lev], d_rhotheta_src[lev],
                                           geom[lev], z_phys_cc[lev]);
         }
@@ -652,14 +651,13 @@ ERF::InitData ()
     {
         h_rhoqt_src.resize(max_level+1, amrex::Vector<Real>(0));
         d_rhoqt_src.resize(max_level+1, amrex::Gpu::DeviceVector<Real>(0));
-	for (int lev = 0; lev <= finest_level; lev++)
-        {
+        for (int lev = 0; lev <= finest_level; lev++) {
             const int domlen = geom[lev].Domain().length(2);
-	    h_rhoqt_src[lev].resize(domlen, 0.0_rt);
+            h_rhoqt_src[lev].resize(domlen, 0.0_rt);
             d_rhoqt_src[lev].resize(domlen, 0.0_rt);
             prob->update_rhoqt_sources(t_new[0],
-                                          h_rhoqt_src[lev], d_rhoqt_src[lev],
-                                          geom[lev], z_phys_cc[lev]);
+                                       h_rhoqt_src[lev], d_rhoqt_src[lev],
+                                       geom[lev], z_phys_cc[lev]);
         }
     }
 

--- a/Source/Microphysics/SAM/Cloud_SAM.cpp
+++ b/Source/Microphysics/SAM/Cloud_SAM.cpp
@@ -12,10 +12,6 @@ void SAM::Cloud () {
 
     constexpr Real an = 1.0/(tbgmax-tbgmin);
     constexpr Real bn = tbgmin*an;
-    constexpr Real ap = 1.0/(tprmax-tprmin);
-    constexpr Real bp = tprmin*ap;
-    constexpr Real ag = 1.0/(tgrmax-tgrmin);
-    constexpr Real bg = tgrmin*ag;
 
     Real fac_cond = m_fac_cond;
     Real fac_sub  = m_fac_sub;
@@ -30,11 +26,6 @@ void SAM::Cloud () {
         auto  qv_array = mic_fab_vars[MicVar::qv]->array(mfi);
         auto qcl_array = mic_fab_vars[MicVar::qcl]->array(mfi);
         auto qci_array = mic_fab_vars[MicVar::qci]->array(mfi);
-
-        auto  qp_array = mic_fab_vars[MicVar::qp]->array(mfi);
-        auto qpr_array = mic_fab_vars[MicVar::qpr]->array(mfi);
-        auto qps_array = mic_fab_vars[MicVar::qps]->array(mfi);
-        auto qpg_array = mic_fab_vars[MicVar::qpg]->array(mfi);
 
         auto   rho_array = mic_fab_vars[MicVar::rho]->array(mfi);
         auto  tabs_array = mic_fab_vars[MicVar::tabs]->array(mfi);
@@ -59,8 +50,7 @@ void SAM::Cloud () {
             int niter;
             Real fff, dfff, dtabs;
             Real lstar, dlstar;
-            Real lstarw, dlstarw;
-            Real lstari, dlstari;
+            Real lstarw, lstari;
             Real delta_qv, delta_qc, delta_qi;
 
             // NOTE: Conversion before iterations is necessary to
@@ -121,9 +111,7 @@ void SAM::Cloud () {
                 do {
                     // Latent heats and their derivatives wrt to T
                     lstarw  = fac_cond;
-                    dlstarw = 0.0;
                     lstari  = fac_fus;
-                    dlstari = 0.0;
                     domn    = 0.0;
 
                     // Saturation moisture fractions

--- a/Source/Microphysics/SAM/IceFall.cpp
+++ b/Source/Microphysics/SAM/IceFall.cpp
@@ -13,9 +13,6 @@ void SAM::IceFall () {
     Real dtn = dt;
     int  nz  = nlev;
 
-    Real fac_cond = m_fac_cond;
-    Real fac_fus  = m_fac_fus;
-
     int kmax, kmin;
     auto qcl   = mic_fab_vars[MicVar::qcl];
     auto qci   = mic_fab_vars[MicVar::qci];
@@ -60,7 +57,6 @@ void SAM::IceFall () {
         auto qn_array    = qn->array(mfi);
         auto qt_array    = qt->array(mfi);
         auto rho_array   = rho->array(mfi);
-        auto tabs_array  = tabs->array(mfi);
         auto fz_array    = fz.array(mfi);
 
         const auto& gbox3d = mfi.tilebox(IntVect(0),IntVect(0,0,1));

--- a/Source/Microphysics/SAM/PrecipFall.cpp
+++ b/Source/Microphysics/SAM/PrecipFall.cpp
@@ -211,9 +211,8 @@ void SAM::PrecipFall (int hydro_type)
             ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 int kc = min(k+1, nz-1);
-
                 Real dqp = (fz_array(i,j,kc)-fz_array(i,j,k)) / rho_array(i,j,k);
-                tmp_qp_array(i,j,k) = tmp_qp_array(i,j,k) + (fz_array(i,j,kc)-fz_array(i,j,k)) / rho_array(i,j,k); //Update temporary qp
+                tmp_qp_array(i,j,k) = tmp_qp_array(i,j,k) + dqp; //Update temporary qp
             });
 
             ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)

--- a/Source/TimeIntegration/ERF_advance_dycore.cpp
+++ b/Source/TimeIntegration/ERF_advance_dycore.cpp
@@ -202,9 +202,9 @@ void ERF::advance_dycore(int level,
     }
 
     if (solverChoice.custom_moisture_forcing) {
-	prob->update_rhoqt_sources(old_time,
-                                      h_rhoqt_src[level], d_rhoqt_src[level],
-                                      fine_geom, z_phys_cc[level]);
+        prob->update_rhoqt_sources(old_time,
+                                   h_rhoqt_src[level], d_rhoqt_src[level],
+                                   fine_geom, z_phys_cc[level]);
     }
 
     // ***********************************************************************************************

--- a/Source/TimeIntegration/ERF_slow_rhs_inc.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_inc.cpp
@@ -99,7 +99,7 @@ void erf_slow_rhs_inc (int /*level*/, int nrk,
                        std::unique_ptr<MultiFab>& mapfac_v,
                        const amrex::Real* dptr_rhotheta_src,
                        const amrex::Real* dptr_rhoqt_src,
-		       const Vector<amrex::Real*> d_rayleigh_dptrs)
+                       const Vector<amrex::Real*> d_rayleigh_dptrs)
 {
     BL_PROFILE_REGION("erf_slow_rhs_pre()");
 
@@ -666,7 +666,7 @@ void erf_slow_rhs_inc (int /*level*/, int nrk,
             }
         }
 
-	if (solverChoice.custom_moisture_forcing) {
+        if (solverChoice.custom_moisture_forcing) {
             const int n = RhoQ1_comp;
             if (solverChoice.custom_forcing_prim_vars) {
                 const int nr = Rho_comp;

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -104,7 +104,6 @@ void erf_slow_rhs_pre (int level, int finest_level,
                        YAFluxRegister* fr_as_crse,
                        YAFluxRegister* fr_as_fine,
                        const amrex::Real* dptr_rhotheta_src,
-                       const amrex::Real* dptr_rhoqt_src,
                        const Vector<amrex::Real*> d_rayleigh_ptrs_at_lev)
 {
     BL_PROFILE_REGION("erf_slow_rhs_pre()");
@@ -738,22 +737,6 @@ void erf_slow_rhs_pre (int level, int finest_level,
                 ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     cell_rhs(i, j, k, n) += dptr_rhotheta_src[k];
-                });
-            }
-        }
-
-        if (solverChoice.custom_moisture_forcing) {
-            const int n = RhoQ1_comp;
-            if (solverChoice.custom_forcing_prim_vars) {
-                const int nr = Rho_comp;
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                {
-                    cell_rhs(i, j, k, n) += cell_data(i,j,k,nr) * dptr_rhoqt_src[k];
-                });
-            } else {
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                {
-                    cell_rhs(i, j, k, n) += dptr_rhoqt_src[k];
                 });
             }
         }

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -105,7 +105,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
                        YAFluxRegister* fr_as_fine,
                        const amrex::Real* dptr_rhotheta_src,
                        const amrex::Real* dptr_rhoqt_src,
-		       const Vector<amrex::Real*> d_rayleigh_ptrs_at_lev)
+                       const Vector<amrex::Real*> d_rayleigh_ptrs_at_lev)
 {
     BL_PROFILE_REGION("erf_slow_rhs_pre()");
 

--- a/Source/TimeIntegration/TI_headers.H
+++ b/Source/TimeIntegration/TI_headers.H
@@ -56,7 +56,7 @@ void erf_slow_rhs_pre (int level, int finest_level, int nrk,
                       amrex::YAFluxRegister* fr_as_fine,
                       const amrex::Real* dptr_rhotheta_src,
                       const amrex::Real* dptr_rhoqt_src,
-		      const amrex::Vector<amrex::Real*> d_rayleigh_ptrs_at_lev);
+                      const amrex::Vector<amrex::Real*> d_rayleigh_ptrs_at_lev);
 
 /**
  * Function for computing the slow RHS for the evolution equations for the scalars other than density or potential temperature
@@ -101,8 +101,7 @@ void erf_slow_rhs_post (int level, int finest_level, int nrk,
                        amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_yhi,
 #endif
                        amrex::YAFluxRegister* fr_as_crse,
-                       amrex::YAFluxRegister* fr_as_fine
-                       );
+                       amrex::YAFluxRegister* fr_as_fine);
 
 /**
  * Function for computing the fast RHS with no terrain
@@ -269,7 +268,7 @@ void erf_slow_rhs_inc (int level, int nrk,
                        std::unique_ptr<amrex::MultiFab>& mapfac_v,
                        const amrex::Real* dptr_rhotheta_src,
                        const amrex::Real* dptr_rhoqt_src,
-		       const Vector<amrex::Real*> d_rayleigh_ptrs_at_lev);
+                       const Vector<amrex::Real*> d_rayleigh_ptrs_at_lev);
 #endif
 
 void ApplySpongeZoneBCs (const SpongeChoice& spongeChoice,

--- a/Source/TimeIntegration/TI_headers.H
+++ b/Source/TimeIntegration/TI_headers.H
@@ -55,7 +55,6 @@ void erf_slow_rhs_pre (int level, int finest_level, int nrk,
                       amrex::YAFluxRegister* fr_as_crse,
                       amrex::YAFluxRegister* fr_as_fine,
                       const amrex::Real* dptr_rhotheta_src,
-                      const amrex::Real* dptr_rhoqt_src,
                       const amrex::Vector<amrex::Real*> d_rayleigh_ptrs_at_lev);
 
 /**
@@ -100,6 +99,7 @@ void erf_slow_rhs_post (int level, int finest_level, int nrk,
                        amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_ylo,
                        amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_yhi,
 #endif
+                       const amrex::Real* dptr_rhoqt_src,
                        amrex::YAFluxRegister* fr_as_crse,
                        amrex::YAFluxRegister* fr_as_fine);
 
@@ -266,8 +266,6 @@ void erf_slow_rhs_inc (int level, int nrk,
                        std::unique_ptr<amrex::MultiFab>& mapfac_m,
                        std::unique_ptr<amrex::MultiFab>& mapfac_u,
                        std::unique_ptr<amrex::MultiFab>& mapfac_v,
-                       const amrex::Real* dptr_rhotheta_src,
-                       const amrex::Real* dptr_rhoqt_src,
                        const Vector<amrex::Real*> d_rayleigh_ptrs_at_lev);
 #endif
 

--- a/Source/TimeIntegration/TI_slow_rhs_fun.H
+++ b/Source/TimeIntegration/TI_slow_rhs_fun.H
@@ -110,7 +110,7 @@
                              z_phys_nd_src[level], detJ_cc_src[level], p0_new,
                              mapfac_m[level], mapfac_u[level], mapfac_v[level],
                              fr_as_crse, fr_as_fine,
-                             dptr_rhotheta_src, dptr_rhoqt_src, d_rayleigh_ptrs_at_lev);
+                             dptr_rhotheta_src, d_rayleigh_ptrs_at_lev);
 
             // We define and evolve (rho theta)_0 in order to re-create p_0 in a way that is consistent
             //    with our update of (rho theta) but does NOT maintain dp_0 / dz = -rho_0 g.  This is why
@@ -203,7 +203,7 @@
                              z_phys_nd[level], detJ_cc[level], p0,
                              mapfac_m[level], mapfac_u[level], mapfac_v[level],
                              fr_as_crse, fr_as_fine,
-                             dptr_rhotheta_src, dptr_rhoqt_src, d_rayleigh_ptrs_at_lev);
+                             dptr_rhotheta_src, d_rayleigh_ptrs_at_lev);
         }
 
 #ifdef ERF_USE_NETCDF
@@ -313,8 +313,8 @@
                               real_width, real_set_width,
                               bdy_data_xlo, bdy_data_xhi, bdy_data_ylo, bdy_data_yhi,
 #endif
-                              fr_as_crse, fr_as_fine
-                              );
+                              dptr_rhoqt_src,
+                              fr_as_crse, fr_as_fine);
         } else {
             erf_slow_rhs_post(level, finest_level, nrk, slow_dt,
                               S_rhs, S_old, S_new, S_data, S_prim, S_scratch,
@@ -329,8 +329,8 @@
                               real_width, real_set_width,
                               bdy_data_xlo, bdy_data_xhi, bdy_data_ylo, bdy_data_yhi,
 #endif
-                              fr_as_crse, fr_as_fine
-                              );
+                              dptr_rhoqt_src,
+                              fr_as_crse, fr_as_fine);
         }
     }; // end slow_rhs_fun_post
 
@@ -363,7 +363,7 @@
                          fine_geom, solverChoice, m_most, domain_bcs_type_d, domain_bcs_type,
                          z_phys_nd[level], detJ_cc[level], p0,
                          mapfac_m[level], mapfac_u[level], mapfac_v[level],
-                         dptr_rhotheta_src, dptr_rhoqt_src, d_rayleigh_ptrs_at_lev);
+                         dptr_rhotheta_src, d_rayleigh_ptrs_at_lev);
 
 
 #ifdef ERF_USE_NETCDF


### PR DESCRIPTION
Please see the contributing material for formatting requirements. We require 4 space indents, no tabs, and no trailing whitespace. You must set your IDE to automate the 4 spaces but we have shell scripts for the tabs and white space. To run those shell scripts use the following commands: `.github/workflows/style/check_trailing_whitespaces.sh` and `.github/workflows/style/check_tabs.sh`. Once those scripts complete, the tabs and trailing spaces will be removed and you can push your mods to remote.